### PR TITLE
Add missing libcups2 dependency for Debian

### DIFF
--- a/packages/docs/docs/miscellaneous/linux-dependencies.mdx
+++ b/packages/docs/docs/miscellaneous/linux-dependencies.mdx
@@ -57,6 +57,7 @@ RUN apt install -y \
   libxdamage1 \
   libpango-1.0-0 \
   libcairo2 \
+  libcups2 \
   libatk-bridge2.0-0
 ```
 


### PR DESCRIPTION
We were updating some dependencies that seemed unrelated to Remotion but started getting a "Failed to launch the browser process!" error, which we traced to the libcups2 package. It was added to the Debian dockerfile [here](https://github.com/remotion-dev/remotion/commit/25cb4ff055304adb4f3147dd7a79a4ff811b8777#diff-cd61de8244d9267e03f2ee40c6e8a2f936dfaf543443ebb7b2da6e51ab709860R20) but not the docs. I don't know whether it's needed on Ubuntu.

Thanks!